### PR TITLE
Add model exporter

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -1,3 +1,4 @@
+from os.path import join
 import numpy as np
 
 DATASET_TRAIN_PATH = 'trainingset.csv'
@@ -5,6 +6,7 @@ DATASET_TEST_PATH = 'testset.csv'
 DATASET_LABEL_NAME = 'ClaimAmount'
 DATASET_INDEX_NAME = 'rowIndex'
 OUTPUT_DIR = 'dist'
+MODEL_PATH = join(OUTPUT_DIR, 'model.sav')
 
 DATASET_TRAIN_RATIO = 0.8
 MIN_REAL_FEATURE_UNIQUE_VALUES = 20

--- a/core/constants_submission.py
+++ b/core/constants_submission.py
@@ -4,14 +4,14 @@ from imblearn.combine import SMOTETomek
 
 from core.constants_feature_set import SIGNIFICANT_RIDGE_COLUMNS, SIGNIFICANT_BINARY_LABEL_COLUMNS, \
     SIGNIFICANT_FORWARD_STEPWISE_COLUMNS, SIGNIFICANT_AUGMENTED_COLUMNS
-from core.model_induction import train_random_forest, train_decision_tree
+from core.model_induction import train_random_forest, train_decision_tree, train_svc
 from core.model_induction_boundary import train_boundary_1, train_boundary_2
 from core.model_induction_nn import train_network_classifier
 from core.model_induction_wrapper import train_wrapped_induction, predicate_accept_brandon, predicate_reject_brandon
 from core.model_regression import train_static_regression, train_linear_regression, train_polynomial_regression
 from core.model_set import ModelSet
 from core.model_set_modifiers import modifier_filter_columns, modify_model, \
-    modifier_balance_binary_data
+    modifier_balance_binary_data, modifier_resample
 
 SUBMISSION1_RIDGE_FEATURE_SET_COUNTS = [1, 3, 7, 5, 10]
 SUBMISSION1_PROPAGATION_FEATURE_SET_COUNTS = [3, 5, 10, 15, 20]
@@ -347,3 +347,26 @@ SUBMISSION4_MODEL_SETS = [
         train_regression_model=train_static_regression,
     ),
 ]
+
+COMPETITION_MODEL_SET = ModelSet(
+    name='Balanced class weights, no bootstrapping, Tomek links removed',
+    train_induction_model=modify_model(
+        train_wrapped_induction,
+        model=RandomForestClassifier(
+            n_estimators=50,
+            class_weight='balanced',
+            bootstrap=False
+        ),
+        predicate_accept=predicate_accept_brandon,
+        predicate_reject=predicate_reject_brandon,
+    ),
+    induction_modifiers=[
+        modifier_filter_columns(SIGNIFICANT_AUGMENTED_COLUMNS),
+        modifier_resample(TomekLinks()),
+    ],
+    train_regression_model=modify_model(train_polynomial_regression, degree=2),
+    regression_modifiers=[
+        modifier_filter_columns(SIGNIFICANT_RIDGE_COLUMNS),
+    ],
+    proba_threshold=1,
+)

--- a/core/model_composite.py
+++ b/core/model_composite.py
@@ -14,6 +14,10 @@ class CompositeModel:
         self._induction_model = self._train_induction_model(induction_train_features, induction_train_label)
         self._regression_model = self._train_regression_model(regression_train_features, regression_train_label)
 
+        # HACK: unset lambdas for pickling
+        self._train_induction_model = None
+        self._train_regression_model = None
+
     def predict(self, induction_test_features, regression_test_features):
         induction_proba = self._induction_model.predict_proba(induction_test_features)[:, 1]
         return [

--- a/core/model_exporter.py
+++ b/core/model_exporter.py
@@ -1,0 +1,64 @@
+import pickle
+import pandas as pd
+
+from core.loader import load_train_dataset, load_determining_dataset
+from core.model_set import train_model_from_model_set
+from core.preprocessing import get_categorical_columns, separate_features_label, \
+    expand_dataset_deterministic, create_augmented_features, convert_label_boolean, \
+    split_claims_accept_reject
+from core.constants import DATASET_LABEL_NAME, MODEL_PATH
+from core.constants_feature_set import SIGNIFICANT_AUGMENTED_COLUMNS
+from core.constants_submission import COMPETITION_MODEL_SET
+
+
+def handle_model_export():
+    fit_and_export_model(load_train_dataset(), COMPETITION_MODEL_SET)
+
+def fit_and_export_model(train_dataset, model_set):
+    train_features, train_labels = separate_features_label(train_dataset, DATASET_LABEL_NAME)
+    categorical_columns = get_categorical_columns(train_dataset)
+    categorical_train_features = train_features.loc[:, categorical_columns]
+    expanded_train_features = expand_dataset_deterministic(
+        train_features,
+        load_determining_dataset(),
+        categorical_columns
+    )
+    augmented_train_features = create_augmented_features(
+        train_features,
+        SIGNIFICANT_AUGMENTED_COLUMNS
+    )
+
+    induction_train_features = pd.concat((
+        expanded_train_features,
+        augmented_train_features,
+        categorical_train_features,
+    ), axis='columns')
+    induction_train_labels = convert_label_boolean(train_labels)
+    induction_data = (induction_train_features, induction_train_labels,
+        pd.DataFrame(columns=induction_train_features.columns),
+        pd.DataFrame(columns=induction_train_features.columns))
+
+    accept_data, _ = split_claims_accept_reject(induction_train_features, train_labels)
+    accept_train_features, accept_train_label = accept_data
+    regression_data = (accept_train_features, accept_train_label,
+        pd.DataFrame(columns=induction_train_features.columns),
+        pd.DataFrame(columns=induction_train_features.columns))
+
+    model = train_model_from_model_set(model_set, induction_data, regression_data)
+    export_model(model)
+
+def import_model_and_predict(test_dataset):
+    model = import_model()
+    # create predictions and write to csv
+
+def export_model(model):
+    with open(MODEL_PATH, mode='wb') as model_file:
+        pickle.dump(model, model_file)
+        print(f'Wrote fitted model to {MODEL_PATH}')
+
+def import_model():
+    with open(MODEL_PATH, mode='rb') as model_file:
+        model = pickle.load(model_file)
+        print(f'Read fitted model from {MODEL_PATH}')
+
+    return model

--- a/core/model_exporter.py
+++ b/core/model_exporter.py
@@ -1,13 +1,8 @@
 import pickle
-import pandas as pd
 
-from core.loader import load_train_dataset, load_determining_dataset
-from core.model_set import train_model_from_model_set
-from core.preprocessing import get_categorical_columns, separate_features_label, \
-    expand_dataset_deterministic, create_augmented_features, convert_label_boolean, \
-    split_claims_accept_reject
-from core.constants import DATASET_LABEL_NAME, MODEL_PATH
-from core.constants_feature_set import SIGNIFICANT_AUGMENTED_COLUMNS
+from core.loader import load_train_dataset
+from core.model_set import train_model_from_model_set, get_model_set_train_data
+from core.constants import MODEL_PATH
 from core.constants_submission import COMPETITION_MODEL_SET
 
 
@@ -15,41 +10,13 @@ def handle_model_export():
     fit_and_export_model(load_train_dataset(), COMPETITION_MODEL_SET)
 
 def fit_and_export_model(train_dataset, model_set):
-    train_features, train_labels = separate_features_label(train_dataset, DATASET_LABEL_NAME)
-    categorical_columns = get_categorical_columns(train_dataset)
-    categorical_train_features = train_features.loc[:, categorical_columns]
-    expanded_train_features = expand_dataset_deterministic(
-        train_features,
-        load_determining_dataset(),
-        categorical_columns
-    )
-    augmented_train_features = create_augmented_features(
-        train_features,
-        SIGNIFICANT_AUGMENTED_COLUMNS
-    )
-
-    induction_train_features = pd.concat((
-        expanded_train_features,
-        augmented_train_features,
-        categorical_train_features,
-    ), axis='columns')
-    induction_train_labels = convert_label_boolean(train_labels)
-    induction_data = (induction_train_features, induction_train_labels,
-        pd.DataFrame(columns=induction_train_features.columns),
-        pd.DataFrame(columns=induction_train_features.columns))
-
-    accept_data, _ = split_claims_accept_reject(induction_train_features, train_labels)
-    accept_train_features, accept_train_label = accept_data
-    regression_data = (accept_train_features, accept_train_label,
-        pd.DataFrame(columns=induction_train_features.columns),
-        pd.DataFrame(columns=induction_train_features.columns))
-
+    induction_data, regression_data = get_model_set_train_data(train_dataset)
     model = train_model_from_model_set(model_set, induction_data, regression_data)
     export_model(model)
 
 def import_model_and_predict(test_dataset):
     model = import_model()
-    # create predictions and write to csv
+    # create predictions using test dataset and write to csv
 
 def export_model(model):
     with open(MODEL_PATH, mode='wb') as model_file:

--- a/main.py
+++ b/main.py
@@ -8,12 +8,12 @@ from core.data_analysis import perform_linear_regression_analysis, perform_polyn
 from core.data_visualization import generate_classification_plots, \
     generate_scatter_plots, generate_histogram_plots, generate_compound_plots, generate_correlation_plots
 from core.loader import load_train_dataset, load_standardized_train_dataset, load_determining_dataset
+from core.model_exporter import handle_model_export
 from core.predict import predict_submission1_ridge, predict_submission1_propagation, predict_submission2, \
     predict_submission3, predict_submission4
 from core.preprocessing import split_training_test, split_claims_accept_reject, \
     separate_features_label, convert_label_binary, get_categorical_columns, expand_dataset_deterministic
 from library.option_input import OptionInput
-from main_induction import perform_induction_tests
 
 
 def run_menu(title, options):
@@ -136,22 +136,15 @@ def main():
 
     def main_menu():
         run_menu('Main menu', [
-            (
-                'Run dev test',
-                run_dev_test
-            ),
-            (
-                'Generate data visualization plots',
-                lambda: data_selection_menu('Select visualization data', visualization_menu)
-            ),
-            (
-                'Perform data analysis',
-                lambda: data_selection_menu('Select analysis data', analysis_menu)
-            ),
-            (
-                'Run model prediction',
-                prediction_menu
-            ),
+            ('Run dev test', run_dev_test),
+            ('Generate data visualization plots', lambda: (
+                data_selection_menu('Select visualization data', visualization_menu)
+            )),
+            ('Perform data analysis', lambda: (
+                data_selection_menu('Select analysis data', analysis_menu)
+            )),
+            ('Run model prediction', prediction_menu),
+            ('Export competition model', handle_model_export),
             MENU_EXIT
         ])
 


### PR DESCRIPTION
Unfortunately needed to add some duplicate code in the training data preprocessing for legacy compatibility. If we ever decide to overhaul the preprocessor to be test data-independent we would have to change a bunch of return signatures for modifiers, etc.